### PR TITLE
Teeny tiny updates following #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .python-version
 .#*
 site/
+*.DS_Store

--- a/docs/curriculum-notes.md
+++ b/docs/curriculum-notes.md
@@ -3,7 +3,7 @@
 These notes have been broken out by session:
 
 [UNIX Notes](curriculum-notes/unix.md)  
-[[Git Notes](curriculum-notes/git.md)  
+[Git Notes](curriculum-notes/git.md)  
 [Python Notes](curriculum-notes/python.md)  
 [R Notes](curriculum-notes/r.md)  
 [Miscellaneous Notes](curriculum-notes/misc.md)  


### PR DESCRIPTION
1. added .DS_Store to gitignore for us Mac users
2. Removed extra hard bracket in the curriculum notes nav page (thanks for adding that! forgot the nav bar would not automatically generate nested links)

I was very careful to pull changes from upstream before doing these, and not a merge conflict was had 🎉 

I was also able to `mkdocs gh-deploy` and `mkdocs serve` looks good so I will open a parallel PR for the gh-pages branch to update the live site.